### PR TITLE
added default value for email claim

### DIFF
--- a/library.js
+++ b/library.js
@@ -110,7 +110,8 @@
 			}
 
 			const settings = constants.pluginSettings.getWrapper();
-
+			//added as removed from UI
+			settings.emailClaim = 'email';
 			// If we are missing any settings
 			if (!settings.clientId ||
 				!settings.clientSecret ||


### PR DESCRIPTION
Since we removed the field from UI, the setup was missing this field causing the plugin to not work.